### PR TITLE
fix / open-close modal on admin page

### DIFF
--- a/pages/administracion/Administración.html
+++ b/pages/administracion/Administración.html
@@ -137,7 +137,7 @@
     <main>
         <div class="container">
             <h2 class="text-white m-3">Agrega un nuevo juego</h2>
-            <button type="button" class="btn btn-outline-warning text-white btn-md m-3" data-bs-toggle="closeModal"
+            <button type="button" class="btn btn-outline-warning text-white btn-md m-3" data-bs-toggle="modal"
                 data-bs-target="#gameModal"><i class="fas fa-plus-circle"></i></button>
             <!-- =================================
                 ==			  MODAL			   ==
@@ -150,8 +150,7 @@
                         <!-- CABECERA DEL MODAL -->
                         <div class="modal-header">
                             <h5 class="modal-title" id="modalLabelGame">Registrar usuario</h5>
-                            <button type="button" class="btn-close" data-bs-dismiss="closeModal"
-                                aria-label="Close"></button>
+                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                         </div>
                         <!-- CUERPO DEL MODAL -->
                         <div class="modal-body">
@@ -206,7 +205,7 @@
                         </div>
                         <!-- PIE DEL MODAL -->
                         <div class="modal-footer d-flex justify-content-between">
-                            <button type="button" class="btn btn-danger" data-bs-dismiss="closeModal">Cancelar</button>
+                            <button type="button" class="btn btn-danger" data-bs-dismiss="modal" aria-label="Close">Cancelar</button>
                             <button type="button" class="btn btn-success">Registrar</button>
                         </div>
                     </div>


### PR DESCRIPTION
Algunos atributos del modal de la página de admin no estaban correctos. Cambie los atributos según la documentación de bootstrap y ahora funciona correctamente. Probablemente habría que chequear con que versión de bootstrap se está trabajando. Saludos!